### PR TITLE
issue #97: add a live simulation progress log

### DIFF
--- a/src/SimuMole/SimuMole/urls.py
+++ b/src/SimuMole/SimuMole/urls.py
@@ -20,5 +20,6 @@ urlpatterns = [
                                                  SimulationForm1_DetermineRelativePosition,
                                                  SimulationForm2_SimulationParameters],
                                                 condition_dict={'1': show_form1})),
+                  path('update_simulation_status/', views.update_simulation_status, name='update_simulation_status'),
                   path('upload/', views.file_upload, name='file_upload'),
               ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/src/SimuMole/SimuMoleWeb/templates/base.html
+++ b/src/SimuMole/SimuMoleWeb/templates/base.html
@@ -4,6 +4,7 @@
     {% load static %}
     <link rel="stylesheet" id="ample-style-css" href="{% static 'SimuMoleWeb/style.css' %}" type="text/css" media="all">
     <link rel="stylesheet" href="{% static 'SimuMoleWeb/style_additions.css' %}" type="text/css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 </head>
 <body class="wide">
 <div id="page" class="hfeed site">

--- a/src/SimuMole/SimuMoleWeb/templates/create_simulation_result.html
+++ b/src/SimuMole/SimuMoleWeb/templates/create_simulation_result.html
@@ -2,15 +2,28 @@
 
 {% block content %}
 
+    <style>
+        #simulation_status {
+            font-weight: bold;
+        }
 
-<title>Simulation Result</title>
+        #simulation_status_during_run {
+            white-space: pre;
+        }
+    </style>
 
+
+    <title>Create Simulation - SimuMole</title>
 
     <h1><strong>Create Your Simulation</strong></h1><br>
 
 
-    <h3>Response entered by you:</h3>
+    <h3>The status of your request:</h3>
+    <p id="simulation_status"> Processing your parameters...</p>
+    <p id="simulation_status_during_run"></p>
 
+
+    <h3>Your input parameters:</h3>
     <ul>
         {% for key, value in form_data.items %}
             <li><strong>{{ key }}</strong> - {{ value }}</li>
@@ -18,3 +31,45 @@
     </ul>
 
 {% endblock %}
+
+{% block extra_js %}
+    <script>
+
+        const interval = setInterval(function () {
+            update_simulation_status_()
+        }, 4000); // unit of milliseconds
+
+        function update_simulation_status_() {
+            $.ajax({
+                url: '{% url 'update_simulation_status' %}',
+                type: "get",
+                cache: true,
+                timeout: 30000,
+                dataType: 'json',
+                success: function (data) {
+
+                    // simulation_status:
+                    if (data['simulation_status'] !== "") {
+                        document.getElementById('simulation_status').textContent = data['simulation_status'];
+                        if (data['simulation_status'] === "Done!") {
+                            clearInterval(interval);
+                        }
+                    }
+
+                    // simulation_status_during_run:
+                    if (data['simulation_status'] === "Running simulation..." && data['simulation_status_during_run'] !== "") {
+                        const simulation_status_during_run = data['simulation_status_during_run'].split(',');
+                        const progress = simulation_status_during_run[0];
+                        const remainingTime = simulation_status_during_run[1];
+                        document.getElementById('simulation_status_during_run').textContent =
+                            'Progress: ' + progress + '\r\n' + 'Remaining Time: ' + remainingTime;
+                    } else {
+                        document.getElementById('simulation_status_during_run').textContent = ''
+                    }
+
+                },
+            });
+        }
+
+    </script>
+{% endblock extra_js %}


### PR DESCRIPTION
### Description:
**Immediately** after the user clicks on the "submit" button, he moved to the page "create_simulation_result.html" (the address is not changed, it is still "create_simulation").

### This page shows the following steps in the simulation creation process:
1. `Processing your parameters`: Preparation before using OpenMM, for example: loading the PDB files, determining the relative position, merging into a single PDB file, and calls to "fix_pdb" function.
2. `Minimizing energy` (this is one of the steps that OpenMM performs).
3. `Equilibrating` (this is one of the steps that OpenMM performs).
4. `Running simulation` (this is one of the steps that OpenMM performs): Two details are displayed: "Progress" and "Remaining time".
5. `Done`.

### Notes about the implementation:
In order to complete this feature, I used the "AJAX request", which allows us to update an html page without refreshing.
The AJAX request makes repeated calls to a view function (called "update_simulation_status"), which checks the status of the run by reading the files that updated by the thread running the simulation.
Both files are saved under "media/ files" folder. File Description:
- "simulation_status.txt": Describes the current step (for example: "Done").
- "simulation_status_during_run.txt": Contains OpenMM's "StateDataReporter" (example line: "20.0%, 0:05").

### Sample screenshots:
![image](https://user-images.githubusercontent.com/37686204/57634873-d0d6ad00-75ae-11e9-9388-bfdcb181fd29.png)

![image](https://user-images.githubusercontent.com/37686204/57634815-ba305600-75ae-11e9-827d-9de178eef9f4.png)

![image](https://user-images.githubusercontent.com/37686204/57634823-bbfa1980-75ae-11e9-9d57-5373c6ce19a7.png)
