### PR TITLE
"create_simulation_result.html" updates

### DIFF
--- a/src/SimuMole/SimuMole/urls.py
+++ b/src/SimuMole/SimuMole/urls.py
@@ -18,13 +18,14 @@ urlpatterns = [
                                                  SimulationForm1_DetermineRelativePosition,
                                                  SimulationForm2_SimulationParameters],
                                                 condition_dict={'1': show_form1})),
-                  path('update_simulation_status/', views.update_simulation_status, name='update_simulation_status'),
 
+                  path('update_simulation_status/', views.update_simulation_status, name='update_simulation_status'),
 
                   path('download_pdb_dcd__zip/', views.download_pdb_dcd__zip, name='download_pdb_dcd__zip'),
                   path('download_pdb_dcd__email/', views.download_pdb_dcd__email, name='download_pdb_dcd__email'),
                   path('download_animation__zip/', views.download_animation__zip, name='download_animation__zip'),
                   path('download_animation__email/', views.download_animation__email, name='download_animation__email'),
-                  path('upload/', views.file_upload, name='file_upload'),
+
+                  path('upload/', views.upload_files, name='upload_files'),
 
               ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/src/SimuMole/SimuMoleScripts/basicTrajectoryBuilder.py
+++ b/src/SimuMole/SimuMoleScripts/basicTrajectoryBuilder.py
@@ -39,8 +39,6 @@ def scr(input_coor_name, temperature, time_step_number):
     update_simulation_status('Running simulation...')
     simulation.step(time_step_number)
 
-    update_simulation_status('Done!')
-
 
 def update_simulation_status(status):
     with open(simulation_status_path, "w+") as f:

--- a/src/SimuMole/SimuMoleScripts/emailSender.py
+++ b/src/SimuMole/SimuMoleScripts/emailSender.py
@@ -35,7 +35,7 @@ def send_email(receiver, file_name):
 
 def send_file_attached(receiver, file_name):
     message = MIMEMultipart("alternative")
-    message["Subject"] = "The files you requested are ready"
+    message["Subject"] = "SimuMole: the files you requested are ready"
     message["From"] = sender
     message["To"] = receiver
     message.attach(MIMEText("The files you requested are attached to this email "
@@ -61,7 +61,7 @@ def send_file_link(receiver, file_name):
     expiration_date = (datetime.datetime.now() + datetime.timedelta(days=7)).strftime('%Y-%m-%d %H:00:00')
 
     message = MIMEMultipart("alternative")
-    message["Subject"] = "The files you requested are ready"
+    message["Subject"] = "SimuMole: the files you requested are ready"
     message["From"] = sender
     message["To"] = receiver
     message.attach(MIMEText("The files you requested are too large to be sent through email.\n"

--- a/src/SimuMole/SimuMoleScripts/simulation_main_script.py
+++ b/src/SimuMole/SimuMoleScripts/simulation_main_script.py
@@ -94,13 +94,32 @@ class Simulation:
 
             # STEP 3: use OpenMM
             input_coor_name = temp + filename_1_movement + pdb
-            scr(input_coor_name, self.temperature, self.time_step_number)
+            try:
+                scr(input_coor_name, self.temperature, self.time_step_number)
+            except:
+                self.update_simulation_status(
+                    'An error occurred while creating the simulation. Please try again later.')
+                return
 
         # save the DCD file using PyMOL
-        self.cmd.reinitialize()
-        self.cmd.load(input_coor_name)
-        self.cmd.load(temp + 'trajectory.dcd')
-        # self.cmd.quit() # todo: need to close PyMol window
+        try:
+            self.cmd.reinitialize()
+            self.cmd.load(input_coor_name)
+            self.cmd.load_traj(temp + 'trajectory.dcd')
+        except:  # mainly for "pymol.CmdException"
+            self.update_simulation_status('An error occurred while creating the simulation. Please try again later.')
+            return
+
+        # create the animations:
+        # todo: complete here this part
+        self.update_simulation_status('Done!')
+
+    @staticmethod
+    def update_simulation_status(status):
+        dir_path = 'media/files/'
+        simulation_status_path = dir_path + 'simulation_status.txt'
+        with open(simulation_status_path, "w+") as f:
+            f.write(status)
 
     def clear_simulation(self):  # todo: complete this! delete all temporary files
         # os.remove('path/to/files')

--- a/src/SimuMole/SimuMoleScripts/uploaded_simulation.py
+++ b/src/SimuMole/SimuMoleScripts/uploaded_simulation.py
@@ -1,15 +1,24 @@
 import pymol
-import os
+
 temp = 'media/files/'  # path to temp folder
 
-class Uploaded_Simulation:
-    def __init__(self, pdb_file_name, dcd_file_name):
-        self.cmd = None
-        self.pdb_file_name = pdb_file_name
-        self.dcd_file_name = dcd_file_name
 
-    def run_simulation(self):
-        pymol.finish_launching(['pymol', '-q'])  # pymol: -q quiet launch, -c no gui, -e fullscreen
-        self.cmd = pymol.cmd
-        self.cmd.load(temp + self.pdb_file_name)
-        self.cmd.load(temp + self.dcd_file_name)
+def pdb_and_dcd_match(pdb_file_name, dcd_file_name):  # todo: remove gui
+    pymol.finish_launching(['pymol', '-q'])  # pymol: -q quiet launch, -c no gui, -e fullscreen
+    cmd = pymol.cmd
+    try:
+        cmd.reinitialize()
+        cmd.load(temp + pdb_file_name)
+        cmd.load_traj(temp + dcd_file_name)
+        return True
+    except:
+        return False
+
+
+def create_animations():
+    # for now, only open pymol window:
+    pymol.finish_launching(['pymol', '-q'])  # pymol: -q quiet launch, -c no gui, -e fullscreen
+    cmd = pymol.cmd
+    cmd.reinitialize()
+    cmd.load(temp + "file_upload_pdb.pdb")
+    cmd.load(temp + "file_upload_dcd.dcd")

--- a/src/SimuMole/SimuMoleScripts/uploaded_simulation.py
+++ b/src/SimuMole/SimuMoleScripts/uploaded_simulation.py
@@ -16,7 +16,7 @@ def pdb_and_dcd_match(pdb_file_name, dcd_file_name):  # todo: remove gui
 
 
 def create_animations():
-    # for now, only open pymol window:
+    # for now, only open pymol window: #todo: create the animations instead of only open PyMOL
     pymol.finish_launching(['pymol', '-q'])  # pymol: -q quiet launch, -c no gui, -e fullscreen
     cmd = pymol.cmd
     cmd.reinitialize()

--- a/src/SimuMole/SimuMoleWeb/templates/create_simulation_result.html
+++ b/src/SimuMole/SimuMoleWeb/templates/create_simulation_result.html
@@ -76,9 +76,9 @@
     </style>
 
 
-    <title>SimuMole: Create Simulation</title>
+    <title>SimuMole: Download Simulation</title>
 
-    {#    <h1><strong>Create Your Simulation</strong></h1><br>#} {#  todo: change title #}
+    <h1><strong>Examine Your Simulation</strong></h1><br>
 
     {################################################################}
     {# simulation status                                            #}
@@ -129,7 +129,7 @@
     {# create the animation                                         #}
     {################################################################}
     <div id="animations_section">
-        <h2>Animations</h2>
+        <h2>Download animations</h2>
 
         <table>
 

--- a/src/SimuMole/SimuMoleWeb/templates/create_simulation_result.html
+++ b/src/SimuMole/SimuMoleWeb/templates/create_simulation_result.html
@@ -78,185 +78,181 @@
 
     <title>SimuMole: Create Simulation</title>
 
-    <h1><strong>Create Your Simulation</strong></h1><br>
+    {#    <h1><strong>Create Your Simulation</strong></h1><br>#} {#  todo: change title #}
 
     {################################################################}
     {# simulation status                                            #}
     {################################################################}
-    <div id="simulation_is_in_processing">
-        <h3>The status of your request</h3>
+    <div id="simulation_status_section">
+        <h2>The status of your request</h2>
         <p id="simulation_status"> Processing your parameters...</p>
         <p id="simulation_status_during_run"></p>
         <br>
     </div>
 
-    {# this section appears only after the simulation is ready    #}
-    <div id="simulation_is_ready">
+    {################################################################}
+    {# download PDB / DCD - via zip or email                        #}
+    {################################################################}
+    <div id="download_pdb_dcd_section">
+        <h2>Download PDB and DCD files</h2>
+        <form action="" method="post"> {% csrf_token %}
+            <p>Select which files to download:</p>
 
-        {################################################################}
-        {# download PDB / DCD - via zip or email                        #}
-        {################################################################}
-        <div>
-            <h2>Download PDB and DCD files</h2>
-            <form action="" method="post"> {% csrf_token %}
-                <p>Select which files to download:</p>
+            {#............................#}
+            {# file checkbox              #}
+            {#............................#}
+            <input type="checkbox" id="pdb_file" onchange="download_pdb_dcd__hide_select_error()">PDB file<br>
+            <input type="checkbox" id="dcd_file" onchange="download_pdb_dcd__hide_select_error()">DCD file<br>
 
-                {#............................#}
-                {# file checkbox              #}
-                {#............................#}
-                <input type="checkbox" id="pdb_file" onchange="download_pdb_dcd__hide_select_error()">PDB file<br>
-                <input type="checkbox" id="dcd_file" onchange="download_pdb_dcd__hide_select_error()">DCD file<br>
-
-                <p class="errorlist" id="download_pdb_dcd__select_error">Select one or more files of the above</p>
-
-                {#............................#}
-                {# download buttons           #}
-                {#............................#}
-                <button type="button" id="download_pdb_dcd__zip_id" onclick="download_pdb_dcd__zip_event()">
-                    Download as zip
-                </button>
-                <br>
-
-                <button type="button" id="download_pdb_dcd__email_id" onclick="download_pdb_dcd__email_event()">
-                    Download via email
-                </button>
-                <input type="text" id="download_pdb_dcd__email" placeholder="Enter email address"
-                       onchange="download_pdb_dcd__hide_email_error()" style="width: 25%;">
-                <p class="errorlist" id="download_pdb_dcd__email_error">Please provide an email address</p>
-                <br>
-
-            </form>
-        </div>
-
-        {################################################################}
-        {# create the animation                                         #}
-        {################################################################}
-        <div>
-            <h2>Create the animation</h2>
-
-            <table>
-
-                <tr>
-
-                    {#............................#}
-                    {# buttons                    #}
-                    {#............................#}
-                    <td id="button_cell" colspan="2">
-                        <button type="submit" id="StartButton" onclick="StartAllVideos()">
-                            {% load static %} <img src="{% static "SimuMoleWeb/icon_play.png" %}" alt="Start">
-                            <p>Play</p>
-                        </button>
-
-                        <button type="submit" id="PauseButton" onclick="PauseAllVideos()">
-                            {% load static %} <img src="{% static "SimuMoleWeb/icon_pause.png" %}" alt="Pause">
-                            <p>Pause</p>
-                        </button>
-
-                        <button type="submit" id="RestartButton" onclick="restart()">
-                            {% load static %} <img src="{% static "SimuMoleWeb/icon_restart.png" %}" alt="Restart">
-                            <p>Restart</p>
-                        </button>
-
-                        <br>
-
-                        <button type="submit" id="MinusFiveButton" onclick="minusFive()">
-                            {% load static %} <img src="{% static "SimuMoleWeb/icon_backward.png" %}" alt="Backward">
-                            <p>-5 frames</p>
-                        </button>
-
-                        <button type="submit" id="PlusFiveButton" onclick="plusFive()">
-                            {% load static %} <img src="{% static "SimuMoleWeb/icon_forward.png" %}" alt="Restart">
-                            <p>+5 frames</p>
-                        </button>
-
-                        <button type="submit" class="gray_button" id="FullControl" onclick="GetFullControl()">
-                            Full Control
-                        </button>
-
-                        <button type="submit" class="gray_button" id="LessControl" onclick="GetLessControl()">
-                            Less Control
-                        </button>
-                    </td>
-
-                    {#............................#}
-                    {# main video                 #}
-                    {#............................#}
-                    <td id="big_video_cell" colspan="4">
-
-                        <video id="big_video" loop muted>
-                            <source src="" type="video/mp4">
-                            Your browser does not support HTML5 video.
-                        </video>
-
-                    </td>
-
-                </tr>
-
-                <tr>
-                    {#............................#}
-                    {# 6 more videos              #}
-                    {#............................#}
-
-                    <td>
-                        <video id="video_1" width="175" height="150" loop muted onclick="play_big(this.id)">
-                            <source src="" type="video/mp4">
-                            Your browser does not support HTML5 video.
-                        </video>
-                    </td>
-                    <td>
-                        <video id="video_2" width="175" height="150" loop muted onclick="play_big(this.id)">
-                            <source src="" type="video/mp4">
-                            Your browser does not support HTML5 video.
-                        </video>
-                    </td>
-                    <td>
-                        <video id="video_3" width="175" height="150" loop muted onclick="play_big(this.id)">
-                            <source src="" type="video/mp4">
-                            Your browser does not support HTML5 video.
-                        </video>
-                    </td>
-                    <td>
-                        <video id="video_4" width="175" height="150" loop muted onclick="play_big(this.id)">
-                            <source src="" type="video/mp4">
-                            Your browser does not support HTML5 video.
-                        </video>
-                    </td>
-                    <td>
-                        <video id="video_5" width="175" height="150" loop muted onclick="play_big(this.id)">
-                            <source src="" type="video/mp4">
-                            Your browser does not support HTML5 video.
-                        </video>
-                    </td>
-                    <td>
-                        <video id="video_6" width="175" height="150" loop muted onclick="play_big(this.id)">
-                            <source src="" type="video/mp4">
-                            Your browser does not support HTML5 video.
-                        </video>
-                    </td>
-
-                </tr>
-
-            </table>
+            <p class="errorlist" id="download_pdb_dcd__select_error">Select one or more files of the above</p>
 
             {#............................#}
             {# download buttons           #}
             {#............................#}
-            <button type="button" id="download_animation__zip_id" onclick="download_animation__zip_event()">
+            <button type="button" id="download_pdb_dcd__zip_id" onclick="download_pdb_dcd__zip_event()">
                 Download as zip
             </button>
             <br>
 
-            <button type="button" id="download_animation__email_id" onclick="download_animation__email_event()">
+            <button type="button" id="download_pdb_dcd__email_id" onclick="download_pdb_dcd__email_event()">
                 Download via email
             </button>
-            <input type="text" id="download_animation__email" placeholder="Enter email address"
-                   onchange="download_animation__hide_email_error()" style="width: 25%;">
-            <p class="errorlist" id="download_animation__email_error">Please provide an email address</p>
+            <input type="text" id="download_pdb_dcd__email" placeholder="Enter email address"
+                   onchange="download_pdb_dcd__hide_email_error()" style="width: 25%;">
+            <p class="errorlist" id="download_pdb_dcd__email_error">Please provide an email address</p>
             <br>
 
-        </div>
+        </form>
+    </div>
+
+    {################################################################}
+    {# create the animation                                         #}
+    {################################################################}
+    <div id="animations_section">
+        <h2>Animations</h2>
+
+        <table>
+
+            <tr>
+
+                {#............................#}
+                {# buttons                    #}
+                {#............................#}
+                <td id="button_cell" colspan="2">
+                    <button type="submit" id="StartButton" onclick="StartAllVideos()">
+                        {% load static %} <img src="{% static "SimuMoleWeb/icon_play.png" %}" alt="Start">
+                        <p>Play</p>
+                    </button>
+
+                    <button type="submit" id="PauseButton" onclick="PauseAllVideos()">
+                        {% load static %} <img src="{% static "SimuMoleWeb/icon_pause.png" %}" alt="Pause">
+                        <p>Pause</p>
+                    </button>
+
+                    <button type="submit" id="RestartButton" onclick="restart()">
+                        {% load static %} <img src="{% static "SimuMoleWeb/icon_restart.png" %}" alt="Restart">
+                        <p>Restart</p>
+                    </button>
+
+                    <br>
+
+                    <button type="submit" id="MinusFiveButton" onclick="minusFive()">
+                        {% load static %} <img src="{% static "SimuMoleWeb/icon_backward.png" %}" alt="Backward">
+                        <p>-5 frames</p>
+                    </button>
+
+                    <button type="submit" id="PlusFiveButton" onclick="plusFive()">
+                        {% load static %} <img src="{% static "SimuMoleWeb/icon_forward.png" %}" alt="Restart">
+                        <p>+5 frames</p>
+                    </button>
+
+                    <button type="submit" class="gray_button" id="FullControl" onclick="GetFullControl()">
+                        Full Control
+                    </button>
+
+                    <button type="submit" class="gray_button" id="LessControl" onclick="GetLessControl()">
+                        Less Control
+                    </button>
+                </td>
+
+                {#............................#}
+                {# main video                 #}
+                {#............................#}
+                <td id="big_video_cell" colspan="4">
+
+                    <video id="big_video" loop muted>
+                        <source src="" type="video/mp4">
+                        Your browser does not support HTML5 video.
+                    </video>
+
+                </td>
+
+            </tr>
+
+            <tr>
+                {#............................#}
+                {# 6 more videos              #}
+                {#............................#}
+
+                <td>
+                    <video id="video_1" width="175" height="150" loop muted onclick="play_big(this.id)">
+                        <source src="" type="video/mp4">
+                        Your browser does not support HTML5 video.
+                    </video>
+                </td>
+                <td>
+                    <video id="video_2" width="175" height="150" loop muted onclick="play_big(this.id)">
+                        <source src="" type="video/mp4">
+                        Your browser does not support HTML5 video.
+                    </video>
+                </td>
+                <td>
+                    <video id="video_3" width="175" height="150" loop muted onclick="play_big(this.id)">
+                        <source src="" type="video/mp4">
+                        Your browser does not support HTML5 video.
+                    </video>
+                </td>
+                <td>
+                    <video id="video_4" width="175" height="150" loop muted onclick="play_big(this.id)">
+                        <source src="" type="video/mp4">
+                        Your browser does not support HTML5 video.
+                    </video>
+                </td>
+                <td>
+                    <video id="video_5" width="175" height="150" loop muted onclick="play_big(this.id)">
+                        <source src="" type="video/mp4">
+                        Your browser does not support HTML5 video.
+                    </video>
+                </td>
+                <td>
+                    <video id="video_6" width="175" height="150" loop muted onclick="play_big(this.id)">
+                        <source src="" type="video/mp4">
+                        Your browser does not support HTML5 video.
+                    </video>
+                </td>
+
+            </tr>
+
+        </table>
+
+        {#............................#}
+        {# download buttons           #}
+        {#............................#}
+        <button type="button" id="download_animation__zip_id" onclick="download_animation__zip_event()">
+            Download as zip
+        </button>
+        <br>
+
+        <button type="button" id="download_animation__email_id" onclick="download_animation__email_event()">
+            Download via email
+        </button>
+        <input type="text" id="download_animation__email" placeholder="Enter email address"
+               onchange="download_animation__hide_email_error()" style="width: 25%;">
+        <p class="errorlist" id="download_animation__email_error">Please provide an email address</p>
+        <br>
 
     </div>
+
 
     {#    <h3>Your input parameters</h3>#}
     {#    <ul>#}
@@ -271,16 +267,37 @@
     <script>
 
         {################################################################}
-        {# simulation status: hide "simulation_is_ready" section until  #}
-        {# the simulation building process is finished                  #}
+        {# Initial layout of the page                                   #}
         {################################################################}
+        previous_page = "{{ previous_page }}";
+        if (previous_page === 'create_simulation') {
+            change_visibility_of_element("simulation_status_section", 'visible', '');
+            change_visibility_of_element("download_pdb_dcd_section", 'hidden', 'none');
+            change_visibility_of_element("animations_section", 'hidden', 'none');
+        } else if (previous_page === 'upload_files') {
+            change_visibility_of_element("simulation_status_section", 'hidden', 'none');
+            change_visibility_of_element("download_pdb_dcd_section", 'hidden', 'none');
+            change_visibility_of_element("animations_section", 'visible', '');
+        }
 
         let video_path = "unknown";
 
-        hide_results(); // hide "simulation_is_ready" section as default
-        const interval = setInterval(function () {
-            update_simulation_status_event()
-        }, 4000); // unit of milliseconds
+        {################################################################}
+        {# simulation status: hide "download_pdb_dcd" and "animations"  #}
+        {# sections until the simulation building process is finished   #}
+        {################################################################}
+
+
+        let interval = "";
+        if (previous_page === 'create_simulation') {
+            interval = setInterval(function () {
+                update_simulation_status_event()
+            }, 4000); // unit of milliseconds
+        }
+        else if (previous_page === 'upload_files') { // the simulation already ready
+            video_path = "{{ video_path }}";
+            init_video_path()
+        }
 
         function update_simulation_status_event() {
             $.ajax({
@@ -297,7 +314,9 @@
                         if (data['simulation_status'] === "Done!") {
                             clearInterval(interval);
                             setTimeout(function () {
-                                show_results();
+                                change_visibility_of_element("simulation_status_section", 'hidden', 'none');
+                                change_visibility_of_element("download_pdb_dcd_section", 'visible', '');
+                                change_visibility_of_element("animations_section", 'visible', '');
                                 video_path = data['video_path'];
                                 init_video_path()
                             }, 1000); // do nothing during 1 seconds and display 'Done!'
@@ -318,19 +337,6 @@
             });
         }
 
-        function show_results() {
-            if (document.getElementById('simulation_is_ready')) {
-                change_visibility_of_element("simulation_is_in_processing", 'hidden', 'none');
-                change_visibility_of_element("simulation_is_ready", '', '');
-            }
-        }
-
-        function hide_results() {
-            if (document.getElementById('simulation_is_ready')) {
-                change_visibility_of_element("simulation_is_ready", 'hidden', 'none');
-            }
-        }
-
         function init_video_path() {
             document.getElementById("big_video").setAttribute('src', video_path + 'video_1' + ".mp4");
             document.getElementById("video_1").setAttribute('src', video_path + 'video_1' + ".mp4");
@@ -349,7 +355,7 @@
         hide_element("download_pdb_dcd__email_error", 'inline');
 
         function download_pdb_dcd__zip_event() {
-            num_of_proteins = {{ form_data.num_of_proteins }};
+            num_of_proteins = {{ num_of_proteins }};
             const pdb_file = document.getElementById("pdb_file").checked;
             const dcd_file = document.getElementById("dcd_file").checked;
 
@@ -369,7 +375,7 @@
         }
 
         function download_pdb_dcd__email_event() {
-            num_of_proteins = {{ form_data.num_of_proteins }};
+            num_of_proteins = {{ num_of_proteins }};
             const pdb_file = document.getElementById("pdb_file").checked;
             const dcd_file = document.getElementById("dcd_file").checked;
             const email = document.getElementById("download_pdb_dcd__email").value;

--- a/src/SimuMole/SimuMoleWeb/templates/create_simulation_result.html
+++ b/src/SimuMole/SimuMoleWeb/templates/create_simulation_result.html
@@ -311,7 +311,8 @@
                     // simulation_status:
                     if (data['simulation_status'] !== "") {
                         document.getElementById('simulation_status').textContent = data['simulation_status'];
-                        if (data['simulation_status'] === "Done!") {
+                        let simulation_status = data['simulation_status'];
+                        if (simulation_status === "Done!") {
                             clearInterval(interval);
                             setTimeout(function () {
                                 change_visibility_of_element("simulation_status_section", 'hidden', 'none');
@@ -320,6 +321,8 @@
                                 video_path = data['video_path'];
                                 init_video_path()
                             }, 1000); // do nothing during 1 seconds and display 'Done!'
+                        } else if (simulation_status.startsWith("An error occurred")) {
+                            clearInterval(interval);
                         }
                     }
 

--- a/src/SimuMole/SimuMoleWeb/templates/create_simulation_result.html
+++ b/src/SimuMole/SimuMoleWeb/templates/create_simulation_result.html
@@ -10,6 +10,12 @@
             margin-bottom: 0;
         }
 
+        .success_message {
+            color: #5e88e7;
+            padding-bottom: 0;
+            margin-bottom: 0;
+        }
+
         {################################################################}
         {# simulation status                                            #}
         {################################################################}
@@ -104,7 +110,9 @@
             <input type="checkbox" id="pdb_file" onchange="download_pdb_dcd__hide_select_error()">PDB file<br>
             <input type="checkbox" id="dcd_file" onchange="download_pdb_dcd__hide_select_error()">DCD file<br>
 
-            <p class="errorlist" id="download_pdb_dcd__select_error">Select one or more files of the above</p>
+            <p class="errorlist" id="download_pdb_dcd__select_error">
+                Select one or more files of the above
+            </p>
 
             {#............................#}
             {# download buttons           #}
@@ -119,7 +127,15 @@
             </button>
             <input type="text" id="download_pdb_dcd__email" placeholder="Enter email address"
                    onchange="download_pdb_dcd__hide_email_error()" style="width: 25%;">
-            <p class="errorlist" id="download_pdb_dcd__email_error">Please provide an email address</p>
+            <p class="errorlist" id="download_pdb_dcd__email_error">
+                Please provide an email address
+            </p>
+            <p class="errorlist" id="download_pdb_dcd__wrong_email_error">
+                An error occurred while sending the email. Please provide a valid email address.
+            </p>
+            <p class="success_message" id="download_pdb_dcd__successful_sending">
+                The email was sent successfully. Please check your inbox
+            </p>
             <br>
 
         </form>
@@ -248,7 +264,15 @@
         </button>
         <input type="text" id="download_animation__email" placeholder="Enter email address"
                onchange="download_animation__hide_email_error()" style="width: 25%;">
-        <p class="errorlist" id="download_animation__email_error">Please provide an email address</p>
+        <p class="errorlist" id="download_animation__email_error">
+            Please provide an email address
+        </p>
+        <p class="errorlist" id="download_animation__wrong_email_error">
+            An error occurred while sending the email. Please provide a valid email address.
+        </p>
+        <p class="success_message" id="download_animation__successful_sending">
+            The email was sent successfully. Please check your inbox
+        </p>
         <br>
 
     </div>
@@ -355,7 +379,9 @@
         {################################################################}
 
         hide_element("download_pdb_dcd__select_error", '');
-        hide_element("download_pdb_dcd__email_error", 'inline');
+        hide_element("download_pdb_dcd__email_error", 'none');
+        hide_element("download_pdb_dcd__wrong_email_error", 'none');
+        hide_element("download_pdb_dcd__successful_sending", 'none');
 
         function download_pdb_dcd__zip_event() {
             num_of_proteins = {{ num_of_proteins }};
@@ -399,9 +425,16 @@
                 dataType: 'json',
                 success:
                     function (response) {
-                        console.log("download_pdb_email__zip: email=" + response['email']); // todo: complete!
+                        let email_success = response['email_success'];
+                        if (email_success === 'true') {
+                            show_element("download_pdb_dcd__successful_sending", 'inline');
+                        }
+                        else if (email_success === 'false') {
+                            show_element("download_pdb_dcd__wrong_email_error", 'inline');
+                        }
                     }
-            });
+            })
+            ;
         }
 
         function download_pdb_dcd__hide_select_error() {
@@ -416,10 +449,22 @@
 
         function download_pdb_dcd__hide_email_error() {
             const email = document.getElementById("download_pdb_dcd__email").value;
-            const error = document.getElementById("download_pdb_dcd__email_error");
-            const error_visibility = error.style.visibility;
-            if (email !== '' && error_visibility === '') {
-                hide_element("download_pdb_dcd__email_error", 'inline')
+
+            const email_error = document.getElementById("download_pdb_dcd__email_error");
+            const email_error_visibility = email_error.style.visibility;
+            if (email !== '' && email_error_visibility === '') {
+                hide_element("download_pdb_dcd__email_error", 'none')
+            }
+            const wrong_email_error = document.getElementById("download_pdb_dcd__wrong_email_error");
+            const wrong_email_error_visibility = wrong_email_error.style.visibility;
+            if (email !== '' && wrong_email_error_visibility === '') {
+                hide_element("download_pdb_dcd__wrong_email_error", 'none')
+            }
+
+            const successful_sending = document.getElementById("download_pdb_dcd__successful_sending");
+            const successful_sending_visibility = successful_sending.style.visibility;
+            if (email !== '' && successful_sending_visibility === '') {
+                hide_element("download_pdb_dcd__successful_sending", 'none')
             }
         }
 
@@ -497,7 +542,9 @@
         }
 
         {# download animation - via zip or email                        #}
-        hide_element("download_animation__email_error", 'inline');
+        hide_element("download_animation__email_error", 'none');
+        hide_element("download_animation__wrong_email_error", 'none');
+        hide_element("download_animation__successful_sending", 'none');
 
         function download_animation__zip_event() {
             $.ajax({
@@ -524,17 +571,35 @@
                 dataType: 'json',
                 success:
                     function (response) {
-                        console.log("download_animation_email__zip: email=" + response['email']); // todo: complete!
+                        let email_success = response['email_success'];
+                        if (email_success === 'true') {
+                            show_element("download_animation__successful_sending", 'inline');
+                        }
+                        else if (email_success === 'false') {
+                            show_element("download_animation__wrong_email_error", 'inline');
+                        }
                     }
             });
         }
 
         function download_animation__hide_email_error() {
             const email = document.getElementById("download_animation__email").value;
-            const error = document.getElementById("download_animation__email_error");
-            const error_visibility = error.style.visibility;
-            if (email !== '' && error_visibility === '') {
-                hide_element("download_animation__email_error", 'inline')
+
+            const email_error = document.getElementById("download_animation__email_error");
+            const email_error_visibility = email_error.style.visibility;
+            if (email !== '' && email_error_visibility === '') {
+                hide_element("download_animation__email_error", 'none')
+            }
+            const wrong_email_error = document.getElementById("download_animation__wrong_email_error");
+            const wrong_email_error_visibility = wrong_email_error.style.visibility;
+            if (email !== '' && wrong_email_error_visibility === '') {
+                hide_element("download_animation__wrong_email_error", 'none')
+            }
+
+            const successful_sending = document.getElementById("download_animation__successful_sending");
+            const successful_sending_visibility = successful_sending.style.visibility;
+            if (email !== '' && successful_sending_visibility === '') {
+                hide_element("download_animation__successful_sending", 'none')
             }
         }
 

--- a/src/SimuMole/SimuMoleWeb/templates/file_upload.html
+++ b/src/SimuMole/SimuMoleWeb/templates/file_upload.html
@@ -2,11 +2,27 @@
 {% block content %}
     <title>SimuMole: Upload PDB & DCD</title>
 
-    <div style="padding:40px;margin:40px;border:1px solid #ccc">
-        <h1>File Upload</h1>
-        <form action="#" method="post" enctype="multipart/form-data">
-            {% csrf_token %} {{ form }}
-            <input type="submit" value="Upload"/>
-        </form>
-    </div>
+    <style>
+
+        .error input, .error select, .errorlist {
+            color: red;
+            padding-bottom: 30px;
+        }
+
+        #blue-button {
+            background-color: #5e88e7;
+            color: black;
+            margin-bottom: 20px;
+        }
+
+    </style>
+
+    <h1><strong>Upload PDB and DCD files</strong></h1><br>
+
+    <form action="" method="post" enctype="multipart/form-data"> {% csrf_token %}
+        {{ form.as_p }}
+        <br>
+        <input id="blue-button" type="submit" value="Upload" class="btn btn-primary"/>
+    </form>
+
 {% endblock %}

--- a/src/SimuMole/SimuMoleWeb/views.py
+++ b/src/SimuMole/SimuMoleWeb/views.py
@@ -237,7 +237,10 @@ class SimulationWizard(CookieWizardView):
             f.write("")
 
         # Render 'create_simulation_result.html' without waiting until the simulation is complete:
-        return render(self.request, 'create_simulation_result.html', {'form_data': form_dict})
+        return render(self.request, 'create_simulation_result.html',
+                      {'form_data': form_dict, 'num_of_proteins': form_dict['num_of_proteins'],
+                       'previous_page': 'create_simulation',
+                       'video_path': settings.MEDIA_URL + 'videos/'})  # todo: change "video_path"
 
     def get_form_initial(self, step):
         """
@@ -294,6 +297,10 @@ def upload_files(request):
         form = UploadFiles(request.POST, request.FILES)
         if form.is_valid():
             create_animations()
+            return render(request, 'create_simulation_result.html',
+                          {'video_path': settings.MEDIA_URL + 'videos/',  # todo: change "video_path"
+                           'previous_page': "upload_files",
+                           'num_of_proteins': 0})  # num_of_proteins is irrelevant
     else:
         form = UploadFiles()
     return render(request, 'file_upload.html', {'form': form})

--- a/src/SimuMole/SimuMoleWeb/views.py
+++ b/src/SimuMole/SimuMoleWeb/views.py
@@ -1,5 +1,7 @@
 from SimuMoleScripts.simulation_main_script import Simulation
 from SimuMoleScripts.uploaded_simulation import create_animations
+from SimuMoleScripts.emailSender import send_email
+
 from .forms import UploadFiles
 
 from formtools.wizard.views import CookieWizardView
@@ -95,11 +97,12 @@ def download_pdb_dcd__email(request):
     include_dcd_file = (request.GET.get('dcd_file') == 'true')
     email = request.GET.get('email')
 
-    download_pdb_dcd__create_zip(num_of_proteins, include_pdb_file, include_dcd_file)
-
-    # todo: complete this function. need to send the mail
-
-    response = {'email': email}
+    response = {'email_success': 'true'}
+    try:
+        download_pdb_dcd__create_zip(num_of_proteins, include_pdb_file, include_dcd_file)
+        send_email(email, "pdb_dcd.zip")
+    except Exception as e:
+        response = {'email_success': 'false'}
 
     return JsonResponse(response)
 
@@ -122,9 +125,13 @@ def download_animation__zip(request):
 
 def download_animation__email(request):
     email = request.GET.get('email')
-    download_animation__create_zip()
-    # todo: complete this function. need to send the mail
-    response = {'email': email}
+
+    response = {'email_success': 'true'}
+    try:
+        download_animation__create_zip()
+        send_email(email, "animations.zip")
+    except:
+        response = {'email_success': 'false'}
     return JsonResponse(response)
 
 

--- a/src/SimuMole/SimuMoleWeb/views.py
+++ b/src/SimuMole/SimuMoleWeb/views.py
@@ -74,8 +74,8 @@ def download_pdb_dcd__create_zip(num_of_proteins, include_pdb_file, include_dcd_
         files.append(os.path.join(settings.MEDIA_ROOT, 'files', 'trajectory.dcd'))
 
     zip_file = zipfile.ZipFile(os.path.join(settings.MEDIA_ROOT, 'files', "pdb_dcd.zip"), "w")
-    for f in files:
-        zip_file.write(f, basename(f))
+    for file, file_name in zip(files, ['pdc.pdb', 'dcd.dcd']):
+        zip_file.write(file, file_name)
     zip_file.close()
 
 


### PR DESCRIPTION
### Upload PDB & DCD:
* Split the form into 2 seperate FileFields.
* Render to `create_simulation_result.html` - only the animations section.
* Until the code for creating the animation is ready - 6 basic animations are displayed, and a PyMOL window is open.
* Add error handling: The PDB file does not match the DCD file. At the moment, the page can not be re-run because the PYMOL window remains open.

### `create_simulation_result.html`:
* Displays an error message if the simulation creation process (`scr` function) raise an exception.
* Create zip: Change the file names in the zip.
* Send mail: Add error handling (but, the function of sending an email, `send_email`, still does not work).